### PR TITLE
Update `package.json` repository property

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "tape": "^4.13.2",
     "vinyl": "^2.2.1"
   },
-  "repository": "git@github.com:LavaMoat/bify-package-factor.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/bify-module-groups.git"
+  }
 }


### PR DESCRIPTION
The `repository` property of `package.json` has been updated to point at the current repository URL. It was also formatted to match the conventions used in our other repositories.