### PR TITLE
feat: allow overriding default stream constructor options

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -2,11 +2,19 @@ const through = require('through2').obj
 const pump = require('pump')
 const pify = require('pify')
 
+const DEFAULT_TRANSFORM_OPTIONS = {
+  highWaterMark: 16,
+  objectMode: true
+}
+
 class ModuleGroup {
-  constructor ({ label, parentGroup }) {
+  constructor ({ label, parentGroup, ...streamOptions }) {
     this.label = label
     this.parentGroup = parentGroup
-    this.stream = through()
+    this.stream = through({
+      ...DEFAULT_TRANSFORM_OPTIONS,
+      ...streamOptions
+    })
   }
 }
 
@@ -14,20 +22,26 @@ module.exports = { createForEachStream, getStreamResults, ModuleGroup }
 
 const noop = () => {}
 
-function createForEachStream ({ onEach = noop, onEnd = noop }) {
-  return through(
-    (entry, _, cb) => { onEach(entry); cb() },
-    (cb) => { onEnd(); cb() }
+function createForEachStream ({ onEach = noop, onEnd = noop, ...streamOptions }) {
+  return through({
+    ...DEFAULT_TRANSFORM_OPTIONS,
+    ...streamOptions
+  },
+  (entry, _, cb) => { onEach(entry); cb() },
+  (cb) => { onEnd(); cb() }
   )
 }
 
-async function getStreamResults (stream) {
+async function getStreamResults (stream, streamOptions) {
   // get bundle results
   const results = []
   await pify(cb => {
     pump(
       stream,
-      createForEachStream({ onEach: (entry) => { results.push(entry) } }),
+      createForEachStream({
+        onEach: (entry) => { results.push(entry) },
+        ...streamOptions
+      }),
       cb
     )
   })()


### PR DESCRIPTION
Allow overriding stream construction options passed to `through2`.

---

#### Blocking
- #5 